### PR TITLE
fix the bug with x0 names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: marssTMB
 Title: Fast fitting of MARSS models with TMB
 Description: Companion to the MARSS package. Fast fitting of MARSS models with TMB. See the MARSS documentation. All the model syntax and features are the same as for the MARSS package.
-Version: 0.0.13
+Version: 0.0.14
 Authors@R: 
     c(person("Eli", "Holmes", , "eli.holmes@noaa.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9128-8393")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# marssTMB 0.0.14
+
+* Bug: if x0 had a column name (which it would if the data had column names), then the line to get the parvec would not have `x0.x0` as the name. It would have `x0` and this would cause a fail of the check that the parvec names match what `MARSSvectorizeparams()` expects.
+
 # marssTMB 0.0.13
 
 * Add check for data class in dfaTMB.

--- a/R/estimate_marss.R
+++ b/R/estimate_marss.R
@@ -195,6 +195,7 @@ estimate_marss <- function(MLEobj, method = c("TMB", "nlminb_TMB", "BFGS_TMB"), 
   numpar <- unlist(lapply(pars, nrow))
   # a vector of the parameters
   pars <- unlist(lapply(pars, function(x) {
+    colnames(x) <- NULL
     x[, 1]
   }))
 

--- a/R/estimate_marss2.R
+++ b/R/estimate_marss2.R
@@ -131,7 +131,7 @@ estimate_marss2 <- function(MLEobj, method = c("TMB", "nlminb_TMB", "BFGS_TMB"),
   par_dims <- lapply(par_dims, as.integer)
   numpar <- unlist(lapply(pars, nrow))
   # a vector of the parameters
-  pars <- unlist(lapply(pars, function(x) { x[, 1] }))
+  pars <- unlist(lapply(pars, function(x) { colnames(x) <- NULL; x[, 1] }))
 
   # Creates the input data list
   # For now, we will assume V0 is a fixed (diagonal) matrix


### PR DESCRIPTION
If x0 had column names, which it could if the data have column names, then the code to get the parvec from the free matrices would not have `x0.x0` but would have `x0`.